### PR TITLE
Fix compatibility issues with older versions.

### DIFF
--- a/bukkit/src/main/java/com/github/koxsosen/bukkit/BukkitPluginLoader.java
+++ b/bukkit/src/main/java/com/github/koxsosen/bukkit/BukkitPluginLoader.java
@@ -53,9 +53,9 @@ public class BukkitPluginLoader extends JavaPlugin {
             if (isBungee) {
                 getLogger().info("This server is proxied.");
                 // We need this channel to be able to send the request.
-                getServer().getMessenger().registerOutgoingPluginChannel(this, "simplevoicebans:custom");
+                getServer().getMessenger().registerOutgoingPluginChannel(this, "simplevbans:custom");
                 // We need this channel to be able to receive the response.
-                getServer().getMessenger().registerIncomingPluginChannel( this, "simplevoicebans:custom", new MessageReceiver());
+                getServer().getMessenger().registerIncomingPluginChannel( this, "simplevbans:custom", new MessageReceiver());
             } else {
                 getLogger().info("This server is not proxied.");
                 getLogger().info("SimpleVoiceBans without LibertyBans installed requires a proxied backend server.");

--- a/bukkit/src/main/java/com/github/koxsosen/bukkit/MessageReceiver.java
+++ b/bukkit/src/main/java/com/github/koxsosen/bukkit/MessageReceiver.java
@@ -12,7 +12,7 @@ import java.util.Map;
 public class MessageReceiver implements PluginMessageListener {
     @Override
     public void onPluginMessageReceived(String channel, @NonNull Player player, byte[] bytes) {
-        if (!channel.equalsIgnoreCase("simplevoicebans:custom")) {
+        if (!channel.equalsIgnoreCase("simplevbans:custom")) {
             return;
         }
 

--- a/bukkit/src/main/java/com/github/koxsosen/bukkit/SimpleVoiceBans.java
+++ b/bukkit/src/main/java/com/github/koxsosen/bukkit/SimpleVoiceBans.java
@@ -102,7 +102,7 @@ public class SimpleVoiceBans implements VoicechatPlugin {
             return;
         }
 
-        player.sendPluginMessage(BukkitPluginLoader.getInstance(),"simplevoicebans:custom", byao.toByteArray());
+        player.sendPluginMessage(BukkitPluginLoader.getInstance(),"simplevbans:custom", byao.toByteArray());
         try {
             byao.close();
         } catch (IOException e) {

--- a/bungeecord/src/main/java/com/github/koxsosen/bungee/BungeePluginLoader.java
+++ b/bungeecord/src/main/java/com/github/koxsosen/bungee/BungeePluginLoader.java
@@ -42,14 +42,14 @@ public class BungeePluginLoader extends Plugin {
         getLogger().info("Loaded SimpleVoiceBans.");
         getLogger().info("Make sure you have SimpleVoiceChat, and SimpleVoiceBans installed on all backend servers.");
 
-        getProxy().registerChannel("simplevoicebans:custom");
+        getProxy().registerChannel("simplevbans:custom");
         getProxy().getPluginManager().registerListener(this, new MessageReceiver());
     }
 
     @Override
     public void onDisable() {
         getProxy().getPluginManager().unregisterListeners(this);
-        getProxy().unregisterChannel("simplevoicebans:custom");
+        getProxy().unregisterChannel("simplevbans:custom");
     }
 
     public static LibertyBansApiHelper getLibertyBansApiHelper() {

--- a/bungeecord/src/main/java/com/github/koxsosen/bungee/MessageReceiver.java
+++ b/bungeecord/src/main/java/com/github/koxsosen/bungee/MessageReceiver.java
@@ -15,7 +15,7 @@ public class MessageReceiver implements Listener {
     @EventHandler
     @SuppressWarnings("unused")
     public void onPluginMessageReceived(PluginMessageEvent event) {
-        if (!event.getTag().equalsIgnoreCase("simplevoicebans:custom")) {
+        if (!event.getTag().equalsIgnoreCase("simplevbans:custom")) {
             return;
         }
 
@@ -67,7 +67,7 @@ public class MessageReceiver implements Listener {
             return;
         }
 
-        player.getServer().getInfo().sendData("simplevoicebans:custom", byao.toByteArray());
+        player.getServer().getInfo().sendData("simplevbans:custom", byao.toByteArray());
         try {
             byao.close();
         } catch (IOException e) {

--- a/velocity/src/main/java/com/github/koxsosen/velocity/VelocityPluginLoader.java
+++ b/velocity/src/main/java/com/github/koxsosen/velocity/VelocityPluginLoader.java
@@ -48,7 +48,7 @@ public class VelocityPluginLoader {
     public static ProxyServer server;
     public static  Logger logger;
 
-    public static final MinecraftChannelIdentifier IDENTIFIER = MinecraftChannelIdentifier.from("simplevoicebans:custom");
+    public static final MinecraftChannelIdentifier IDENTIFIER = MinecraftChannelIdentifier.from("simplevbans:custom");
 
     @Inject
     public VelocityPluginLoader(ProxyServer server, Logger logger) {


### PR DESCRIPTION
As reported in #2, older versions may limit the channel name to a specific amount of characters. This PR ensures that we stay under this limit.